### PR TITLE
Mention lexical error calls in error messages

### DIFF
--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -180,6 +180,9 @@
       to update their manifests if they wish to allow this feature.  See
       \url{https://blog.r-project.org/2023/03/07/path-length-limit-on-windows}
       for more information.
+
+      \item \sQuote{Object not found} errors now mention a more accurate
+      context of error.
     }
   }
 

--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -183,6 +183,9 @@
 
       \item \sQuote{Object not found} errors now mention a more accurate
       context of error.
+
+      \item \sQuote{Object not found} and \sQuote{Missing argument}
+      errors now mention a more accurate context of error.
     }
   }
 

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -1329,6 +1329,9 @@ enum {
     CTXT_UNWIND   = 128
 };
 
+extern0 RCNTXT *getLexicalContext(SEXP);
+extern0 SEXP getLexicalCall(SEXP);
+
 /*
 TOP   0 0 0 0 0 0  = 0
 NEX   1 0 0 0 0 0  = 1

--- a/src/main/context.c
+++ b/src/main/context.c
@@ -620,22 +620,42 @@ attribute_hidden SEXP do_sysbrowser(SEXP call, SEXP op, SEXP args, SEXP rho)
 /* We don't want to count the closure that do_sys is contained in, so the */
 /* indexing is adjusted to handle this. */
 
+/* Return first `CTXT_FUNCTION` context whose execution
+   env matches `rho` */
+attribute_hidden RCNTXT *getLexicalContext(SEXP rho)
+{
+    RCNTXT *cptr = R_GlobalContext;
+
+    while (cptr && cptr != R_ToplevelContext) {
+	if (cptr->callflag & CTXT_FUNCTION && cptr->cloenv == rho)
+	    break;
+	cptr = cptr->nextcontext;
+    }
+
+    return cptr;
+}
+
+/* Return call of the first `CTXT_FUNCTION` context whose
+   execution env matches `rho` */
+attribute_hidden SEXP getLexicalCall(SEXP rho)
+{
+    RCNTXT *cptr = getLexicalContext(rho);
+    if (cptr)
+	return cptr->call;
+    else
+	return R_NilValue;
+}
+
 attribute_hidden SEXP do_sys(SEXP call, SEXP op, SEXP args, SEXP rho)
 {
     int i, n  = -1, nframe;
-    SEXP rval, t;
-    RCNTXT *cptr;
+    SEXP rval;
 
     checkArity(op, args);
+
     /* first find the context that sys.xxx needs to be evaluated in */
-    cptr = R_GlobalContext;
-    t = cptr->sysparent;
-    while (cptr != R_ToplevelContext) {
-	if (cptr->callflag & CTXT_FUNCTION )
-	    if (cptr->cloenv == t)
-		break;
-	cptr = cptr->nextcontext;
-    }
+    SEXP t = R_GlobalContext->sysparent;
+    RCNTXT *cptr = getLexicalContext(t);
 
     if (length(args) == 1) n = asInteger(CAR(args));
 

--- a/src/main/eval.c
+++ b/src/main/eval.c
@@ -1020,7 +1020,9 @@ SEXP eval(SEXP e, SEXP rho)
 	else
 	    tmp = findVar(e, rho);
 	if (tmp == R_UnboundValue)
-	    error(_("object '%s' not found"), EncodeChar(PRINTNAME(e)));
+	    errorcall(getLexicalCall(rho),
+		      _("object '%s' not found"),
+		      EncodeChar(PRINTNAME(e)));
 	/* if ..d is missing then ddfindVar will signal */
 	else if (tmp == R_MissingArg && !DDVAL(e) ) {
 	    const char *n = CHAR(PRINTNAME(e));
@@ -5397,9 +5399,11 @@ NORET static void MISSING_ARGUMENT_ERROR(SEXP symbol)
 #define MAYBE_MISSING_ARGUMENT_ERROR(symbol, keepmiss) \
     do { if (! keepmiss) MISSING_ARGUMENT_ERROR(symbol); } while (0)
 
-NORET static void UNBOUND_VARIABLE_ERROR(SEXP symbol)
+NORET static void UNBOUND_VARIABLE_ERROR(SEXP symbol, SEXP rho)
 {
-    error(_("object '%s' not found"), EncodeChar(PRINTNAME(symbol)));
+    errorcall(getLexicalCall(rho),
+	      _("object '%s' not found"),
+	      EncodeChar(PRINTNAME(symbol)));
 }
 
 static R_INLINE SEXP FORCE_PROMISE(SEXP value, SEXP symbol, SEXP rho,
@@ -5443,7 +5447,7 @@ static R_INLINE SEXP getvar(SEXP symbol, SEXP rho,
 	value = findVar(symbol, rho);
 
     if (value == R_UnboundValue)
-	UNBOUND_VARIABLE_ERROR(symbol);
+	UNBOUND_VARIABLE_ERROR(symbol, rho);
     else if (value == R_MissingArg)
 	MAYBE_MISSING_ARGUMENT_ERROR(symbol, keepmiss);
     else if (TYPEOF(value) == PROMSXP) {

--- a/src/main/eval.c
+++ b/src/main/eval.c
@@ -1026,9 +1026,11 @@ SEXP eval(SEXP e, SEXP rho)
 	/* if ..d is missing then ddfindVar will signal */
 	else if (tmp == R_MissingArg && !DDVAL(e) ) {
 	    const char *n = CHAR(PRINTNAME(e));
-	    if(*n) error(_("argument \"%s\" is missing, with no default"),
-			 CHAR(PRINTNAME(e)));
-	    else error(_("argument is missing, with no default"));
+	    if(*n) errorcall(getLexicalCall(rho),
+			     _("argument \"%s\" is missing, with no default"),
+			     CHAR(PRINTNAME(e)));
+	    else errorcall(getLexicalCall(rho),
+			   _("argument is missing, with no default"));
 	}
 	else if (TYPEOF(tmp) == PROMSXP) {
 	    if (PRVALUE(tmp) == R_UnboundValue) {
@@ -5389,15 +5391,17 @@ static R_INLINE SEXP GET_BINDING_CELL_CACHE(SEXP symbol, SEXP rho,
     }
 }
 
-NORET static void MISSING_ARGUMENT_ERROR(SEXP symbol)
+NORET static void MISSING_ARGUMENT_ERROR(SEXP symbol, SEXP rho)
 {
     const char *n = CHAR(PRINTNAME(symbol));
-    if(*n) error(_("argument \"%s\" is missing, with no default"), n);
-    else error(_("argument is missing, with no default"));
+    if(*n) errorcall(getLexicalCall(rho),
+		     _("argument \"%s\" is missing, with no default"), n);
+    else errorcall(getLexicalCall(rho),
+		   _("argument is missing, with no default"));
 }
 
-#define MAYBE_MISSING_ARGUMENT_ERROR(symbol, keepmiss) \
-    do { if (! keepmiss) MISSING_ARGUMENT_ERROR(symbol); } while (0)
+#define MAYBE_MISSING_ARGUMENT_ERROR(symbol, keepmiss, rho) \
+    do { if (! keepmiss) MISSING_ARGUMENT_ERROR(symbol, rho); } while (0)
 
 NORET static void UNBOUND_VARIABLE_ERROR(SEXP symbol, SEXP rho)
 {
@@ -5448,9 +5452,9 @@ static R_INLINE SEXP getvar(SEXP symbol, SEXP rho,
 
     if (value == R_UnboundValue)
 	UNBOUND_VARIABLE_ERROR(symbol, rho);
-    else if (value == R_MissingArg)
-	MAYBE_MISSING_ARGUMENT_ERROR(symbol, keepmiss);
-    else if (TYPEOF(value) == PROMSXP) {
+    else if (value == R_MissingArg) {
+	MAYBE_MISSING_ARGUMENT_ERROR(symbol, keepmiss, rho);
+    } else if (TYPEOF(value) == PROMSXP) {
 	SEXP pv = PRVALUE(value);
 	if (pv == R_UnboundValue) {
 	    PROTECT(value);

--- a/tests/reg-tests-2.R
+++ b/tests/reg-tests-2.R
@@ -3311,3 +3311,26 @@ stopifnot(eval(x) == 4, eval(parse(text = deparse(x))) == 4)
 dput(packageDate("foo"))
 ## gave *five* warnings* in R <= 4.2.x
 
+
+## object not found error mentions lexical call
+if (exists("foo")) rm(foo)
+## Should not mention call because called at top level
+try(identity(foo))
+try(do.call("identity", alist(foo)))
+##
+## Should mention `f()` call
+f <- function() identity(foo)
+try(f())
+f <- compiler::cmpfun(f)
+try(f())
+f <- function() do.call("identity", alist(foo))
+try(f())
+f <- compiler::cmpfun(f)
+try(f())
+##
+## Should not mention call because there is no matching execution env
+try(do.call("identity", alist(foo), envir = new.env()))
+f <- function() do.call("identity", alist(foo), envir = new.env())
+try(f())
+f <- compiler::cmpfun(f)
+try(f())

--- a/tests/reg-tests-2.R
+++ b/tests/reg-tests-2.R
@@ -3334,3 +3334,37 @@ f <- function() do.call("identity", alist(foo), envir = new.env())
 try(f())
 f <- compiler::cmpfun(f)
 try(f())
+
+
+## Missing argument error mentions lexical call
+## Local evaluation: Mentions `identity()`
+try(identity())
+f <- function() identity()
+try(f())
+f <- compiler::cmpfun(f)
+try(f())
+##
+## Promise evaluation: Mentions `f()` or `g()`
+f <- function(arg) is.factor(arg)
+g <- function(x) f(x)
+try(f())
+try(g())
+f <- compiler::cmpfun(f)
+g <- compiler::cmpfun(g)
+try(f())
+try(g())
+##
+## Direct evaluation, `eval()` wrapper: Mentions `eval()`
+f <- function() eval(quote(expr = ))
+try(f())
+f <- compiler::cmpfun(f)
+try(f())
+##
+## Direct evaluation, no `eval()` wrapper: Mentions `f()`
+f <- function() {
+    eval(bquote(delayedAssign("go", .(quote(expr = )))))
+    go
+}
+try(f())
+f <- compiler::cmpfun(f)
+try(f())

--- a/tests/reg-tests-2.Rout.save
+++ b/tests/reg-tests-2.Rout.save
@@ -8259,3 +8259,36 @@ In packageDescription(pkg, lib.loc = lib.loc, fields = date.fields) :
 > ## gave *five* warnings* in R <= 4.2.x
 > 
 > 
+> 
+> ## object not found error mentions lexical call
+> if (exists("foo")) rm(foo)
+> ## Should not mention call because called at top level
+> try(identity(foo))
+Error : object 'foo' not found
+> try(do.call("identity", alist(foo)))
+Error : object 'foo' not found
+> ##
+> ## Should mention `f()` call
+> f <- function() identity(foo)
+> try(f())
+Error in f() : object 'foo' not found
+> f <- compiler::cmpfun(f)
+> try(f())
+Error in f() : object 'foo' not found
+> f <- function() do.call("identity", alist(foo))
+> try(f())
+Error in f() : object 'foo' not found
+> f <- compiler::cmpfun(f)
+> try(f())
+Error in f() : object 'foo' not found
+> ##
+> ## Should not mention call because there is no matching execution env
+> try(do.call("identity", alist(foo), envir = new.env()))
+Error : object 'foo' not found
+> f <- function() do.call("identity", alist(foo), envir = new.env())
+> try(f())
+Error : object 'foo' not found
+> f <- compiler::cmpfun(f)
+> try(f())
+Error : object 'foo' not found
+> 

--- a/tests/reg-tests-2.Rout.save
+++ b/tests/reg-tests-2.Rout.save
@@ -6629,8 +6629,7 @@ Error in complete.cases(list(), list()) :
 > ## error messages from (C-level) evalList
 > tst <- function(y) { stopifnot(is.numeric(y)); y+ 1 }
 > try(tst()) # even nicer since R 3.5.0's change to sequential stopifnot()
-Error in stopifnot(is.numeric(y)) : 
-  argument "y" is missing, with no default
+Error in tst() : argument "y" is missing, with no default
 > try(c(1,,2))
 Error in c(1, , 2) : argument 2 is empty
 > ## change in 2.8.0 made these less clear
@@ -8259,7 +8258,6 @@ In packageDescription(pkg, lib.loc = lib.loc, fields = date.fields) :
 > ## gave *five* warnings* in R <= 4.2.x
 > 
 > 
-> 
 > ## object not found error mentions lexical call
 > if (exists("foo")) rm(foo)
 > ## Should not mention call because called at top level
@@ -8291,4 +8289,49 @@ Error : object 'foo' not found
 > f <- compiler::cmpfun(f)
 > try(f())
 Error : object 'foo' not found
+> 
+> 
+> ## Missing argument error mentions lexical call
+> ## Local evaluation: Mentions `identity()`
+> try(identity())
+Error in identity() : argument "x" is missing, with no default
+> f <- function() identity()
+> try(f())
+Error in identity() : argument "x" is missing, with no default
+> f <- compiler::cmpfun(f)
+> try(f())
+Error in identity() : argument "x" is missing, with no default
+> ##
+> ## Promise evaluation: Mentions `f()` or `g()`
+> f <- function(arg) is.factor(arg)
+> g <- function(x) f(x)
+> try(f())
+Error in f() : argument "arg" is missing, with no default
+> try(g())
+Error in g() : argument "x" is missing, with no default
+> f <- compiler::cmpfun(f)
+> g <- compiler::cmpfun(g)
+> try(f())
+Error in f() : argument "arg" is missing, with no default
+> try(g())
+Error in g() : argument "x" is missing, with no default
+> ##
+> ## Direct evaluation, `eval()` wrapper: Mentions `eval()`
+> f <- function() eval(quote(expr = ))
+> try(f())
+Error in eval(quote(expr = )) : argument is missing, with no default
+> f <- compiler::cmpfun(f)
+> try(f())
+Error in eval(quote(expr = )) : argument is missing, with no default
+> ##
+> ## Direct evaluation, no `eval()` wrapper: Mentions `f()`
+> f <- function() {
++     eval(bquote(delayedAssign("go", .(quote(expr = )))))
++     go
++ }
+> try(f())
+Error in f() : argument is missing, with no default
+> f <- compiler::cmpfun(f)
+> try(f())
+Error in f() : argument is missing, with no default
 > 


### PR DESCRIPTION
Patch 1:

```r
f <- function() identity(foo)

# Before
f()
#> Error in `identity()`:
#> ! object 'foo' not found

# After
f()
#> Error in `f()`:
#> ! object 'foo' not found
```

Patch 2:

```r
# Before
grepl("foo")
#> Error in `is.factor()`:
#> ! argument "x" is missing, with no default

# After
grepl("foo")
#> Error in `grepl()`:
#> ! argument "x" is missing, with no default
```